### PR TITLE
Fix for ZEN-22976 - prodbin pull request builds are broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME         ?= pydeps
-VERSION      ?= 5.2.0-el7-1
+VERSION      ?= 5.2.0-el7-2
 PRODNAME     := $(NAME)-$(VERSION)
 DESTDIR      := dest
 OUTPUT       := $(DESTDIR)/$(PRODNAME).tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ metrology==0.9.0
 networkx==1.7
 poster==0.6.0
 protobuf==2.5.0
+cryptography==1.0.1
 pyOpenSSL==0.14
 pyasn1==0.1.7
 pycrypto>=2.6.0


### PR DESCRIPTION
Pin to a specific version of the cryptography package to fix build issues.