### PR TITLE
Use Acquisition 2.13.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME         ?= pydeps
-VERSION      ?= 5.2.0-el7-8-dev
+VERSION      ?= 5.2.0-el7-9-dev
 PRODNAME     := $(NAME)-$(VERSION)
 DESTDIR      := dest
 OUTPUT       := $(DESTDIR)/$(PRODNAME).tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 AccessControl==2.13.7
-Acquisition==2.13.8
+Acquisition==2.13.8.1
 alabaster==0.7.9
 amqp==1.0.13
 amqplib==1.0.2


### PR DESCRIPTION
We forked Acquisition and modified it to allow sub-classing of the acquisition wrappers.  This PR bumps the version of Acquisition to pick up our changes, which are here:

https://github.com/zenoss/Acquisition/pull/1

This was needed for the fix for ZEN-24152, which is here:

https://github.com/zenoss/zenoss-prodbin/pull/1831