### PR TITLE
Add solrcloudpy 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,6 +95,7 @@ service-identity==16.0.0
 six==1.9.0
 snowballstemmer==1.2.1
 socketIO-client==0.5.3
+solrcloudpy==2.4.1
 Sphinx==1.4.5
 suds==0.4
 supervisor==3.3.1


### PR DESCRIPTION
This is needed for zenoss/model-index