### PR TITLE
bump to next dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME         ?= pydeps
-VERSION      ?= 5.2.0-el7-11-dev
+VERSION      ?= 5.2.0-el7-13-dev
 PRODNAME     := $(NAME)-$(VERSION)
 DESTDIR      := dest
 OUTPUT       := $(DESTDIR)/$(PRODNAME).tar.gz


### PR DESCRIPTION
After releasing 5.2.0-el7-12, the next dev version is 5.2.0-el7-13-dev.  It looks like the last release incorrectly set the dev version, so 12-dev was skipped.