### PR TITLE
update python-dateutil to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ pycrypto==2.6.1
 Pygments==2.1.3
 PyMySQL==0.6.3
 pyOpenSSL==0.14
-python-dateutil==1.5
+python-dateutil==2.6.0
 python-ldap==2.4.6
 python-memcached==1.57
 pytz==2012rc0


### PR DESCRIPTION
ZEN-27773 - update python-dateutil. 1.5 doesn't parse iso 8601 date format as well as 2.6.0 does.