### PR TITLE
Bump develop version to 5.3.0-el7-2-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME         ?= pydeps
-VERSION      ?= 5.2.0-el7-13-dev
+VERSION      ?= 5.3.0-el7-2-dev
 PRODNAME     := $(NAME)-$(VERSION)
 DESTDIR      := dest
 OUTPUT       := $(DESTDIR)/$(PRODNAME).tar.gz


### PR DESCRIPTION
Note:
This PR is being marked as `Build finished. No test results found` not because of its content but because of an outdated Jenkins plugin. The tests actually do pass, but github is not notified of that success. Please consider accepting this PR after manually checking the results.