### PR TITLE
Bump cryptography package version to 1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ celery==3.0.15
 cffi==1.7.0
 collective.beaker==1.0b3
 ConcurrentLogHandler==0.9.1
-cryptography==1.0.1
+cryptography==1.9
 DateTime==2.12.7
 decorator==3.4.0
 defusedxml==0.4.1


### PR DESCRIPTION
The previous version of cryptography (1.0.1) does not work with PyJWT.  We cannot use the most recent version due to an incompatibility with LDAPMultiPlugin; 1.9 is the most recent version that we can use.

See [ZEN-29514](https://jira.zenoss.com/browse/ZEN-29514) for more information about this limitation.


**Note:**
This PR is being marked as `Build finished. No test results found.` not because of its content but because of an outdated Jenkins plugin.  The tests actually _do_ pass, but github is not notified of that success. Please consider accepting this PR after manually checking the results.