### PR TITLE
ZEN-29514: Need to upgrade OpenSSL to supported version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cffi==1.11.5
 chardet==3.0.4
 collective.beaker==1.0b3
 ConcurrentLogHandler==0.9.1
-cryptography==1.9
+cryptography==2.0
 DateTime==2.12.7
 decorator==3.4.0
 defusedxml==0.4.1
@@ -86,7 +86,7 @@ pycrypto==2.6.1
 Pygments==2.1.3
 PyJWT==1.5.3
 PyMySQL==0.6.3
-pyOpenSSL==0.14
+pyOpenSSL==16.2.0
 python-dateutil==2.6.0
 python-ldap==2.4.6
 python-memcached==1.57


### PR DESCRIPTION
Update the pyOpenSSL package to prevent the
`AttributeError: 'module' object has no attribute 'SSL_ST_INIT'` error
in LDAPMultiPlugin