### PR TITLE
ZEN-32252: Add pysnmp to optional requirements

### DIFF
--- a/requirements_opt.txt
+++ b/requirements_opt.txt
@@ -1,1 +1,2 @@
 pysnmp==4.4.12
+beautifulsoup4==4.8.1


### PR DESCRIPTION
Fixes: ZEN-32252