### PR TITLE
BLD-232: move zenpip packages into requirements_zen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ OUTPUT          := $(DESTDIR)/$(PRODNAME).tar.gz
 TMPDIR          := /tmp
 WHEELDIR        := wheelhouse
 BUILDDIR        := $(TMPDIR)/$(NAME)-$(VERSION)
-REQUIREMENTS    := requirements.txt
+REQUIREMENTS_3RD := requirements_3rd.txt
+REQUIREMENTS_ZEN := requirements_zen.txt
 REQUIREMENTS_OPT := requirements_opt.txt
 PKGMAKEFILE     := Makefile.pkg
 CENTOS_BASE_TAG := 1.1.7-java
@@ -42,15 +43,21 @@ $(OUTPUT): $(BUILDDIR)/$(WHEELDIR) $(DESTDIR)
 
 # The atomic package requires special attention. The CFFI package needs
 # to installed so that a proper binary wheel can be built for atomic.
-CFFI_REQ := $(shell sed -n '/cffi/p' $(REQUIREMENTS))
+CFFI_REQ := $(shell sed -n '/cffi/p' $(REQUIREMENTS_3RD))
 
 $(BUILDDIR)/$(WHEELDIR): $(BUILDDIR)
 	@sudo pip install $(CFFI_REQ)
 	@pip wheel --wheel-dir=$@ \
+		-r $(REQUIREMENTS_3RD) wheel
+	@cp $(REQUIREMENTS_3RD) $(BUILDDIR)
+
+	# Add zenoss local packages
+	@pip wheel --wheel-dir=$@ \
 		--extra-index-url http://zenpip.zenoss.eng/simple/ \
 		--trusted-host zenpip.zenoss.eng \
-		-r $(REQUIREMENTS) wheel
-	@cp $(REQUIREMENTS) $(BUILDDIR)
+		-r $(REQUIREMENTS_ZEN) wheel
+	@cp $(REQUIREMENTS_ZEN) $(BUILDDIR)
+
 	# Add Optional package requirements
 	@pip wheel --wheel-dir=$@ \
 		--extra-index-url http://zenpip.zenoss.eng/simple/ \

--- a/requirements_3rd.txt
+++ b/requirements_3rd.txt
@@ -91,11 +91,9 @@ python-dateutil==2.6.0
 python-ldap==3.1.0
 python-memcached==1.57
 pytz==2012rc0
-PyXML==0.8.4
 PyYAML==3.10
 Record==2.13.0
 redis==2.7.2
-RelStorage==2.0.0.1.dev15
 requests==2.20.1
 RestrictedPython==3.6.0
 service-identity==16.0.0
@@ -117,11 +115,9 @@ ujson==1.23
 unittest2==1.1.0
 urllib3==1.24
 websocket-client==0.37.0
-Yapps==2.1.1
 zc.lockfile==1.0.0
 ZConfig==2.9.1
 zdaemon==2.0.4
-zenpacksupport==1.0
 ZEO==4.3.1
 zExceptions==2.13.0
 zLOG==2.11.1
@@ -130,7 +126,6 @@ ZODB3==3.10.5
 zodbpickle==0.6.0
 Zope2==2.13.13
 zope.annotation==3.5.0
-zope-app-compat==1.0
 zope.broken==3.6.0
 zope.browser==1.3
 zope.browsermenu==3.9.1

--- a/requirements_zen.txt
+++ b/requirements_zen.txt
@@ -1,0 +1,14 @@
+# PyXML is deprecated, but preserved on the zenpip server
+PyXML==0.8.4
+
+# RelStorage is maintained on pypi, but v2.0.0.1.dev15 is out of date, and preserved on zenpip
+RelStorage==2.0.0.1.dev15
+
+# Yapps is maintained on pypi, but v2.1.1 is out of date, and preserved on zenpip
+Yapps==2.1.1
+
+# Zenoss supplied package
+zenpacksupport==1.0
+
+#  Zenoss supplied package
+zope-app-compat==1.0


### PR DESCRIPTION
fixes: BLD-232

* prioritize pypi package source over zenpip
* separate zenpip and pypi package requirements files