### PR TITLE
Upgrade protobuf for EnterpriseSecurity ZP 2.0

### DIFF
--- a/requirements_3rd.txt
+++ b/requirements_3rd.txt
@@ -84,7 +84,7 @@ Products.StandardCacheManagers==2.13.0
 Products.ZCatalog==2.13.22
 Products.ZCTextIndex==2.13.3
 Products.ZSQLMethods==2.13.4
-protobuf==2.5.0
+protobuf==3.11.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.18


### PR DESCRIPTION
The 2.0 version of the EnterpriseSecurity ZenPack uses 3rd party libraries that require a version of protobuf >= 3.4 release.