### PR TITLE
ZEN-31325 upgrade PyYAML lib to 5.2

### DIFF
--- a/requirements_3rd.txt
+++ b/requirements_3rd.txt
@@ -97,7 +97,7 @@ python-dateutil==2.6.0
 python-ldap==3.1.0
 python-memcached==1.57
 pytz==2012rc0
-PyYAML==3.10
+PyYAML==5.2
 Record==2.13.0
 redis==2.7.2
 requests==2.20.1

--- a/requirements_3rd.txt
+++ b/requirements_3rd.txt
@@ -97,7 +97,7 @@ python-dateutil==2.6.0
 python-ldap==3.1.0
 python-memcached==1.57
 pytz==2012rc0
-PyYAML==5.2
+PyYAML==5.3
 Record==2.13.0
 redis==2.7.2
 requests==2.20.1


### PR DESCRIPTION
Upgrade PyYAML to 5.2

The latest PyYAML release is 5.3 with some fixes. Which version do we better upgrade to?